### PR TITLE
Rename `register_lister` and `list_unit` routes to `/api/lister/create` and `/api/unit/create`

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -27,8 +27,8 @@ def get_data():
     cur.close()
     return {'message':rv}
 
-@app.route('/register_lister', methods = ["POST"])
-def register_lister():
+@app.route('/api/lister/create', methods = ["POST"])
+def create_lister():
     conn = mysql.connection
     cur = conn.cursor()
 
@@ -56,8 +56,8 @@ def register_lister():
     else: # user already exists
         return {"status": False, "message": "This username is taken!"}
 
-@app.route('/list_unit', methods = ["POST"])
-def list_unit():
+@app.route('/api/unit/create', methods = ["POST"])
+def create_unit():
     conn = mysql.connection
     cur = conn.cursor()
 

--- a/app/src/components/Register/index.js
+++ b/app/src/components/Register/index.js
@@ -23,7 +23,7 @@ const Register = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await axios.post("/register_lister", {
+    const res = await axios.post("/api/lister/create", {
       ...formValues,
     });
     setFormValues({

--- a/app/src/components/UnitForm/index.js
+++ b/app/src/components/UnitForm/index.js
@@ -47,7 +47,7 @@ const UnitForm = ({ handleClose }) => {
   };
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await axios.post("/list_unit", {
+    const res = await axios.post("/api/unit/create", {
       ...postData,
     });
     console.log(res);


### PR DESCRIPTION
This PR changes the existing lister and unit routes to more verbose names `/api/lister/create` and `/api/unit/create`, and also changes the calls in the frontend to reflect the new backend routes. This makes the route structure more clear in development and also to the markers.