### PR TITLE
Add User ID to frontend (AuthContext)

### DIFF
--- a/app/src/components/Login/index.js
+++ b/app/src/components/Login/index.js
@@ -43,6 +43,7 @@ const Login = () => {
       } else {
         dispatch({ type: "LOGIN", payload: data.session.username });
         localStorage.setItem("user", data.session.username);
+        localStorage.setItem("userId", data.session.id);
         navigate(-1);
         toast.success("Logged in successfully.");
       }

--- a/app/src/components/Navbar/index.js
+++ b/app/src/components/Navbar/index.js
@@ -23,6 +23,7 @@ const Navbar = () => {
     });
     if (data.success) {
       localStorage.removeItem("user");
+      localStorage.removeItem("userId");
       dispatch({ type: "LOGOUT" });
       toast.success("Logged out successfully.");
     }

--- a/app/src/context/AuthContext.js
+++ b/app/src/context/AuthContext.js
@@ -16,6 +16,7 @@ export const authReducer = (state, action) => {
 export const AuthContextProvider = ({ children }) => {
   const [state, dispatch] = useReducer(authReducer, {
     user: localStorage.getItem("user"),
+    id: localStorage.getItem("id"),
   });
 
   return (


### PR DESCRIPTION
This PR adds the UserID to localStorage and the AuthContext, so that it can be easily retrieved in the frontend to determine the id of a logged in user.

## Usage
```javascript
import useAuth from 'hooks/useAuth'
...
const { userId } = useAuth();
...
```

Acceptance Criteria
- After logging in, go to localStorage in devTools and check that the userId shows with proper value
- You can access userId from the useAuth() hook
- On logout, the userId is removed from localStorage