### PR TITLE
Small Frontend Changes (empty comment on review & building icon)

### DIFF
--- a/app/src/components/BuildingList/index.js
+++ b/app/src/components/BuildingList/index.js
@@ -59,7 +59,6 @@ const BuildingList = ({ buildings }) => {
             <TableBody>
               {buildings.map(({ building_id, ...building }) => (
                 <TableRow key={building_id}>
-                  {console.log(building.type_of_unit)}
                   <TableCell align="center">
                     {building.type_of_unit === "Apartment" ? (
                       <ApartmentIcon />

--- a/app/src/components/BuildingList/index.js
+++ b/app/src/components/BuildingList/index.js
@@ -11,7 +11,8 @@ import {
   Grid,
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
-import ManageSearchIcon from "@mui/icons-material/ManageSearch";
+import ApartmentIcon from "@mui/icons-material/Apartment";
+import HomeIcon from "@mui/icons-material/Home";
 import React from "react";
 
 const BuildingList = ({ buildings }) => {
@@ -58,13 +59,13 @@ const BuildingList = ({ buildings }) => {
             <TableBody>
               {buildings.map(({ building_id, ...building }) => (
                 <TableRow key={building_id}>
+                  {console.log(building.type_of_unit)}
                   <TableCell align="center">
-                    <Link
-                      component={RouterLink}
-                      to={`/buildings/${building_id}`}
-                    >
-                      <ManageSearchIcon />
-                    </Link>
+                    {building.type_of_unit === "Apartment" ? (
+                      <ApartmentIcon />
+                    ) : (
+                      <HomeIcon />
+                    )}
                   </TableCell>
                   <TableCell
                     component={RouterLink}

--- a/app/src/components/ReviewCard/index.js
+++ b/app/src/components/ReviewCard/index.js
@@ -33,7 +33,7 @@ const ReviewCard = ({ review }) => {
           />
         </Box>
       </Stack>
-      <Typography>"{review.comment}"</Typography>
+      {review.comment && <Typography>"{review.comment}"</Typography>}
       <Typography>— Happy Hippo</Typography>
       <Box
         display="flex"


### PR DESCRIPTION
This PR implements two small frontend changes for better user experience.

1. If a user leaves an empty comment on a review, no quotation marks are rendered
2. In the building list at `/buildings`, an apartment/house icon is rendered for each building

Acceptance Criteria
- Leaving an empty comment on a review shows no quotation marks
- If a new building is created as an apartment, an apartment icon is rendered at `/buildings`
- If a new building is created as a house, a house icon is rendered at `/buildings`