### PR TITLE
Update Reviews Backend Route

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -255,14 +255,11 @@ def update_review():
     conn = mysql.connection
     cur = conn.cursor()
 
-    json_data = request.get_json()
-    review_id = json_data["review_id"]
-    review_helpfulness = json_data["review_helpfulness"]
-    
+    review_id = request.args.get("id")    
 
     try:
-        cur.execute("UPDATE Review SET review_helpfulness=%s WHERE review_id=%s", 
-        [review_helpfulness, review_id])
+        cur.execute("UPDATE Review SET review_helpfulness = review_helpfulness + 1  WHERE review_id=%s", 
+        [review_id])
         cur.close()
         conn.commit()
         return {"success": True}

--- a/api/app.py
+++ b/api/app.py
@@ -216,7 +216,7 @@ def list_unit():
     except Exception as e:
         return {"success": False, "message": f"Error creating listing: {e}"}, STATUS_BAD_REQUEST
 
-@app.route('/api/review/create', methods = ["POST"])
+@app.route('/api/reviews/create', methods = ["POST"])
 def post_review():
     conn = mysql.connection
     cur = conn.cursor()
@@ -250,7 +250,7 @@ def get_review():
 
     return {"success": True, "reviews": reviews}
 
-@app.route('/api/review/update', methods = ["PUT"])
+@app.route('/api/reviews/update', methods = ["PUT"])
 def update_review():
     conn = mysql.connection
     cur = conn.cursor()

--- a/api/app.py
+++ b/api/app.py
@@ -250,6 +250,25 @@ def get_review():
 
     return {"success": True, "reviews": reviews}
 
+@app.route('/api/review/update', methods = ["PUT"])
+def update_review():
+    conn = mysql.connection
+    cur = conn.cursor()
+
+    json_data = request.get_json()
+    review_id = json_data["review_id"]
+    review_helpfulness = json_data["review_helpfulness"]
+    
+
+    try:
+        cur.execute("UPDATE Review SET review_helpfulness=%s WHERE review_id=%s", 
+        [review_helpfulness, review_id])
+        cur.close()
+        conn.commit()
+        return {"success": True}
+    except Exception as e:
+        return {"success": False, "message": f"Error updating comment: {e}"}, STATUS_BAD_REQUEST
+
 
 @app.route('/api/login', methods = ["POST"])
 def login():

--- a/app/src/components/ReviewForm/index.js
+++ b/app/src/components/ReviewForm/index.js
@@ -25,7 +25,7 @@ const ReviewForm = ({ user, building_id }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await axios.post("/api/review/create", {
+    const res = await axios.post("/api/reviews/create", {
       cleanliness,
       adminHelpfulness,
       comment,


### PR DESCRIPTION
This PR adds the ability to update the `review_helpfulness` when users like a review. For the sake of simplicity, you pass through only the `review_id` as a request param, and the `review_helpfulness` will increment by 1 (since nothing else about the review we will allow to change. The FE post route was also changed to match the updated backend route to create reviews (/api/review/create -> /api/reviews/create).

**Acceptance Criteria**
- [ ] Look for an existing review in the DB (can take from `production_data.sql`)
- [ ] Pass the `review_id` to the backend route
- [ ] Query the review to see if the `review_helpfulness` was update successfully. 