### PR TITLE
Add Password hashing to Backend

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,7 @@
+bcrypt==4.0.1
 click==8.1.3
 Flask==2.2.2
+Flask-Bcrypt==1.0.1
 Flask-MySQLdb==1.0.1
 importlib-metadata==5.0.0
 itsdangerous==2.1.2
@@ -8,6 +10,7 @@ MarkupSafe==2.1.1
 mysqlclient==2.1.1
 numpy==1.23.4
 opencv-python==4.6.0.66
+Pillow==9.3.0
 protobuf==4.21.7
 python-dotenv==0.21.0
 Werkzeug==2.2.2


### PR DESCRIPTION
This PR adds password hashing to the backend. Code changes are made in the the `api/lister/create` route to store the hashed password, and the `api/login` route, to verify the provided password against the hashed. 

**Acceptance Criteria**
- [ ] Run pip install to make sure the required modules are installed.
- [ ] Create a new user using the `/api/lister/create` route, so that the password stored in the DB is hashed.
- [ ] Attempt to login with the username created, and check to make sure the login is successful with a correct password, and throws an error with a wrong one. 