### PR TITLE
Return Encoded Image data as Byte64 string

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -207,8 +207,9 @@ def list_unit():
             return {"success": False, "message": result["message"]}, STATUS_BAD_REQUEST
  
     data = image.split(',')
-    relative_image_path = '/images/' + f'{str(uuid.uuid4())[:8]}{image_name}'
-    filename = images_path + f'{str(uuid.uuid4())[:8]}{image_name}'
+    unique_id = str(uuid.uuid4())[:8]
+    relative_image_path = '/images/' + f'{unique_id}{image_name}'
+    filename = images_path + f'{unique_id}{image_name}'
 
     try:
         save_image(filename, data[1])

--- a/api/app.py
+++ b/api/app.py
@@ -119,7 +119,22 @@ def get_units():
     else: # return all units
         cur.execute(f"SELECT * FROM AvailableUnit;")
         rv = cur.fetchall()
-
+    
+    if not rv:
+        return {"success": False}, STATUS_BAD_REQUEST
+    # append image data to returned tuple
+    if type(rv) == tuple:
+        rv = list(rv)
+    else:
+        rv = [rv]
+   
+    for r in rv:
+        file_name = basedir + r['image_path']
+        img = cv2.imread(file_name)
+        jpg_img = cv2.imencode('.jpg',img)
+        b64_string = base64.b64encode(jpg_img[1]).decode('utf-8')
+        r["image_data"] = b64_string
+    rv = tuple(rv)
     cur.close()
     return {"data": rv} # rv is a dictionary if provided id, otherwise a list of dictionaries
 

--- a/app/src/components/UnitCard/index.js
+++ b/app/src/components/UnitCard/index.js
@@ -16,13 +16,16 @@ const UnitCard = ({ unit, addressDict }) => {
   const unitAddress = addressArr.find(
     (building) => addressDict[building] === unit.building_id
   );
+
+  const imgsrc = "data:image/png;base64," + unit.image_data;
+
   return (
     <Card>
       <CardMedia
         component="img"
         height="200"
         image={
-          unit.image_path ||
+          imgsrc ||
           "https://user-images.githubusercontent.com/194400/49531010-48dad180-f8b1-11e8-8d89-1e61320e1d82.png"
         }
       />


### PR DESCRIPTION
This PR encodes the image stored in the `images` folder and appends the data to the returned tuple under `image_data`. 

**Acceptance Criteria**
- [x] @martinx0520 Since you will work with decoding the `image_data` string to an image to display on the frontend, let me know if you have any problems. You can work on the frontend changes in this branch to keep the related changes together.